### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cachetools==3.1.1
 certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
-fuzzywuzzy==0.17.0
 google-api-python-client==1.7.9
 google-auth==1.6.3
 google-auth-httplib2==0.0.3
@@ -23,7 +22,7 @@ pydbus==0.6.0
 pydub==0.23.1
 PyGObject==3.32.1
 PyGObject-stubs==0.0.2
-python-Levenshtein==0.12.0
+rapidfuzz==0.7.6
 requests==2.22.0
 requests-oauthlib==1.2.0
 rsa==4.0

--- a/src/voiceassistant.py
+++ b/src/voiceassistant.py
@@ -13,7 +13,7 @@ from definitions import SNOWBOY_MODEL_PATH
 import threading
 
 # Fuzzy logic
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 # DBus
 from pydbus import SessionBus
@@ -116,8 +116,8 @@ class VoiceAssistant(object):
 
         for identifier, triggers_vector in commands:
             for string in triggers_vector:
-                fuzzy_ratio = fuzz.ratio(cmd_text, string)
-                if fuzzy_ratio > identified_command['percent']:
+                fuzzy_ratio = fuzz.ratio(cmd_text, string, score_cutoff=identified_command['percent'])
+                if fuzzy_ratio:
                     identified_command['cmd'] = identifier
                     identified_command['percent'] = fuzzy_ratio
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy